### PR TITLE
Update workflow to use stakater-user

### DIFF
--- a/.github/workflows/closed_pr.yaml
+++ b/.github/workflows/closed_pr.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/pull_request_closed.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/pull_request_closed.yaml@v0.0.24

--- a/.github/workflows/delete_branch.yaml
+++ b/.github/workflows/delete_branch.yaml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   delete:
-    uses: stakater/.github/.github/workflows/branch_deleted.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/branch_deleted.yaml@v0.0.24
     secrets:
       GH_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   doc_qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.24
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content
       MD_LINT_CONFIG: markdownlint.yaml
   build_container:
     if: ${{ github.base_ref == 'main' }}
-    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.24
     with:
       DOCKER_BUILD_CONTEXTS: content=https://github.com/stakater/mto-docs.git#pull-request-deployments
       DOCKER_FILE_PATH: Dockerfile
@@ -26,4 +26,4 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
       DOCKER_SECRETS: GIT_AUTH_TOKEN=${{ secrets.STAKATER_GITHUB_TOKEN }}
   deploy_doc:
-    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.24

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.24
     secrets:
       GH_TOKEN: ${{ secrets.STAKATER_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   create_release:
-    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.24
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
   build_container:
-    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.23
+    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.24
     with:
       DOCKER_BUILD_CONTEXTS: content=https://github.com/stakater/mto-docs.git#gh-pages
       DOCKER_FILE_PATH: Dockerfile


### PR DESCRIPTION
Have also added branch protection rules for `gh-pages` and `pull-request-deployments` to only allow `stakater-user` to push to them.