### PR TITLE
change regexp to match any character after names

### DIFF
--- a/content/reference-guides/integrationconfig.md
+++ b/content/reference-guides/integrationconfig.md
@@ -23,9 +23,9 @@ spec:
   openshift:
     privilegedNamespaces:
       - ^default$
-      - ^openshift*
-      - ^kube*
-      - ^stakater*
+      - ^openshift.*
+      - ^kube.*
+      - ^stakater.*
 ```
 
 After mentioning the required regex (`^stakater*`) under `privilegedNamespaces`, Bill can create the namespace without interference.


### PR DESCRIPTION
* is dependant on previous letter. ^openshift* means:
"From beginning of line, match 'openshif', also match t 0-infity times and then match anything"
^openshift.* means:
"From beginning of line, match 'openshift', then match anything"