### PR TITLE
Latest theme

### DIFF
--- a/.github/workflows/closed_pr.yaml
+++ b/.github/workflows/closed_pr.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/pull_request_closed.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/pull_request_closed.yaml@v0.0.103
     secrets:
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/delete_branch.yaml
+++ b/.github/workflows/delete_branch.yaml
@@ -4,7 +4,7 @@ on: delete
 
 jobs:
   delete:
-    uses: stakater/.github/.github/workflows/branch_deleted.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/branch_deleted.yaml@v0.0.103
     with:
       LATEST_DOC_VERSION: "1.0"
     secrets:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,7 +13,12 @@ jobs:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content README.md
       MD_LINT_CONFIG: .markdownlint.yaml
+  deploy_doc:
+    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.103
+    secrets:
+      GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
   build_container:
+    needs: deploy_doc
     if: ${{ github.base_ref == 'main' }}
     uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.103
     with:
@@ -25,8 +30,3 @@ jobs:
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
       DOCKER_SECRETS: GIT_AUTH_TOKEN=${{ secrets.PUBLISH_TOKEN }}
-
-  deploy_doc:
-    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.103
-    secrets:
-      GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   doc_qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.103
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content README.md
       MD_LINT_CONFIG: .markdownlint.yaml
   build_container:
     if: ${{ github.base_ref == 'main' }}
-    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/pull_request_container_build.yaml@v0.0.103
     with:
       DOCKER_BUILD_CONTEXTS: content=https://github.com/stakater/mto-docs.git#pull-request-deployments
       DOCKER_FILE_PATH: Dockerfile
@@ -27,6 +27,6 @@ jobs:
       DOCKER_SECRETS: GIT_AUTH_TOKEN=${{ secrets.PUBLISH_TOKEN }}
 
   deploy_doc:
-    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.103
     secrets:
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.103
     with:
       LATEST_DOC_VERSION: "1.0"
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   create_release:
-    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.103
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
   build_container:
-    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.101
+    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.103
     with:
       DOCKER_BUILD_CONTEXTS: content=https://github.com/stakater/mto-docs.git#gh-pages
       DOCKER_FILE_PATH: Dockerfile

--- a/DockerfileLocal
+++ b/DockerfileLocal
@@ -14,7 +14,7 @@ RUN pip install -r theme_common/requirements.txt
 # RUN pip install -r requirements.txt
 
 # pre-mkbuild step, we are infusing common and local theme changes
-RUN python theme_common/scripts/combine_theme_resources.py theme_common/resources theme_override/resources dist/_theme
+RUN python theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
 RUN python theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml
 
 RUN rm -f 'prepare_theme.sh' && \

--- a/prepare_theme.sh
+++ b/prepare_theme.sh
@@ -1,3 +1,3 @@
 pip install -r theme_common/requirements.txt
-python theme_common/scripts/combine_theme_resources.py theme_common/resources theme_override/resources dist/_theme
+python theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
 python theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml

--- a/prepare_theme_pr.sh
+++ b/prepare_theme_pr.sh
@@ -1,0 +1,6 @@
+# This script is meant to be used for pull request builds
+pip install -r theme_common/requirements.txt
+python theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
+# The next step is used to override resources for pull request builds - these overrides could as well have been put in the local theme_override folder, but this is a generic solution
+python theme_common/scripts/combine_theme_resources.py -s theme_common/resources_pr_specific -ov theme_override/resources -o dist/_theme -skiprmtree
+python theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml


### PR DESCRIPTION
* Follow-up from https://github.com/stakater/.github/pull/132
  * Add `prepare_theme_pr.sh`
* Fetch latest theme, specifically to pick up https://github.com/stakater/stakater-docs-mkdocs-theme/pull/52
  * Update combine theme script to use arguments
  * Create override for PR builds
* Fix bug in pull request workflow, apparently the PR Docker image has always been built before the versioned docs have been deployed - it has to be in the reverse order, the docs have to be deployed first on the `pull-request-deployments` branch before the image can be built based on the content on that branch

In short, the effect this will have is that it will create a PR specific banner for PR deployments, highlighting that it is a PR build.