### PR TITLE
Control concurrency of PR deployment jobs

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,6 +14,9 @@ jobs:
       DOC_SRC: content README.md
       MD_LINT_CONFIG: .markdownlint.yaml
   deploy_doc:
+    concurrency:
+      group: pull_request_versioned_doc
+      cancel-in-progress: false
     uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.122
     secrets:
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}


### PR DESCRIPTION
Currently, multiple PR jobs triggered at the same time can cause this error in the ["Deploy PR docs" step](https://github.com/stakater/.github/blob/5de20027dffe555ff62dfeef70ddaede6ff83452/.github/workflows/pull_request_versioned_doc.yaml#L55):

```txt
error: failed to push branch pull-request-deployments to origin:
  To https://github.com/stakater/mto-docs
   ! [rejected]          pull-request-deployments -> pull-request-deployments (fetch first)
  error: failed to push some refs to 'https://github.com/stakater/mto-docs'
  hint: Updates were rejected because the remote contains work that you do not
  hint: have locally. This is usually caused by another repository pushing to
  hint: the same ref. If you want to integrate the remote changes, use
  hint: 'git pull' before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

This often happens when Renovate opens dependency updates for multiple doc branches at the same time. This is mainly a problem for versioned docs, since it contains multiple branches with similar dependencies.

What this change should do is group all deployment jobs into a group called `pull_request_versioned_doc` and only execute jobs in that group sequentially. Any jobs in progress will not be canceled. Read more about concurrency [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs).