### PR TITLE
Update rewrites

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -4,9 +4,9 @@ server {
     index index.html;
     error_page 403 404 @error4xx;
     location @error4xx {
-        rewrite ^/(.*)/ /$1/404.html last;
+        rewrite ^/([^/]*) /$1/404.html last;
     }
-    location = /content/how-to-guides/template.html {
+    location ~* ^/[^/]*/how-to-guides/template.html {
         return 301 $scheme://docs.stakater.com/mto/latest/kubernetes-resources/template/template.html;
     }
     # redirects issued by nginx will be relative


### PR DESCRIPTION
Fixes two issues:

1. The 404 rewrite currently only works on one level. If you go to for example https://docs.stakater.com/mto/latest/pricing.html2 it gives 404, but https://docs.stakater.com/mto/latest/pricing.html2/asdf does not work. With this change, all error rewrites will get the current version from the regex and redirect to the 404 page of that version
    * In essence, what this rewrite `rewrite ^/([^/]*) /$1/404.html last;` will do, when it encounters an error page such as `https://docs.stakater.com/mto/versionX/wrong/wrong.html`, it will parse this part `/versionX/wrong/wrong.html`, and return `/versionX/404.html`. The behavior will be the same for all versions, and will work since all version folders have a 404 page.
    * What the regex incorrectly does right now, is to return `versionX/wrong/404.html` when the page is nested multiple levels, so we have the incorrect behavior that we need to address
1. The redirect for the template page should work as expected with this change. It will consider the version when parsing the URI, and redirect as needed.