### PR TITLE
script to merge sub-operator docs SA-8508

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   doc_qa:
-    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.131
+    uses: stakater/.github/.github/workflows/pull_request_doc_qa.yaml@v0.0.189
     with:
       MD_CONFIG: .github/md_config.json
       DOC_SRC: content README.md

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,9 +17,12 @@ jobs:
     concurrency:
       group: pull_request_versioned_doc
       cancel-in-progress: false
-    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.147
+    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@feat/hook-in-version-doc
+    with:
+      PRE_BUILD_HOOK: make merge
     secrets:
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+      PRE_BUILD_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
   build_container:
     needs: deploy_doc
     if: ${{ github.base_ref == 'main' }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
     concurrency:
       group: pull_request_versioned_doc
       cancel-in-progress: false
-    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@feat/hook-in-version-doc
+    uses: stakater/.github/.github/workflows/pull_request_versioned_doc.yaml@v0.0.189
     with:
       PRE_BUILD_HOOK: make merge
     secrets:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,8 +8,10 @@ on:
 
 jobs:
   push:
-    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.131
+    uses: stakater/.github/.github/workflows/push_versioned_doc.yaml@v0.0.189
     with:
       LATEST_DOC_VERSION: "1.8"
+      PRE_BUILD_HOOK: make merge
     secrets:
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+      PRE_BUILD_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   create_release:
-    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.131
+    uses: stakater/.github/.github/workflows/release_template.yaml@v0.0.189
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
   build_container:
-    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.131
+    uses: stakater/.github/.github/workflows/push_container_only.yaml@v0.0.189
     with:
       DOCKER_BUILD_CONTEXTS: content=https://github.com/stakater/mto-docs.git#gh-pages
       DOCKER_FILE_PATH: Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,8 @@ mkdocs.yml
 .idea
 styles
 
-test/
+test/.venv/
+.superpowers/
+.venv/
+__pycache__/
+.suboperators/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ mkdocs.yml
 styles
 
 test/.venv/
-.superpowers/
 .venv/
 __pycache__/
 .suboperators/

--- a/DockerfileLocal
+++ b/DockerfileLocal
@@ -17,6 +17,17 @@ RUN pip install -r theme_common/requirements.txt
 RUN python theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
 RUN python theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml
 
+# Optionally merge sub-operator docs into the site. Skipped unless
+# MERGE_SUBOP_REPOS is provided (space-separated slug=path pairs pointing at
+# sub-operator repos made available in the build, e.g. via --build-context).
+# Runs after the config-combine so nav is injected into the final mkdocs.yml.
+ARG MERGE_SUBOP_REPOS=""
+RUN if [ -n "$MERGE_SUBOP_REPOS" ]; then \
+      python scripts/merge_docs.py $(for r in $MERGE_SUBOP_REPOS; do echo --set-repo "$r"; done); \
+    else \
+      echo "merge_docs: skipped (MERGE_SUBOP_REPOS not set)"; \
+    fi
+
 RUN rm -f 'prepare_theme.sh' && \
     rm -rf theme_global && \
     rm -rf theme_common

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Local automation for building the docs with merged sub-operator content.
+#
+# The sub-operator repos to merge (and their mappings) are defined in merge.yaml.
+# `make merge` is also what the CI pre-build hook runs (see .github/workflows).
+VENV := .venv
+PY   := $(VENV)/bin/python
+
+.DEFAULT_GOAL := help
+.PHONY: help venv merge serve clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+venv: ## Create the local virtualenv if missing
+	@test -x $(PY) || python3 -m venv $(VENV)
+	@$(VENV)/bin/pip install -q --upgrade pip
+
+# Clones the repos in merge.yaml and merges their docs into content/ + mkdocs.yml.
+# Assumes mkdocs.yml already exists (produced by the theme-combine step). This is
+# exactly what the CI pre-build hook runs; use `make serve` for a standalone
+# local preview. Set PRE_BUILD_TOKEN to clone private repos.
+merge: ## Clone sub-operator repos and merge their docs (the CI pre-build hook)
+	bash scripts/pre_build_merge.sh
+
+serve: venv ## Full local preview: combine theme, merge sub-operator docs, mkdocs serve
+	git submodule update --init --recursive
+	$(VENV)/bin/pip install -q -r theme_common/requirements.txt
+	$(PY) theme_common/scripts/combine_theme_resources.py -s theme_common/resources -ov theme_override/resources -o dist/_theme
+	$(PY) theme_common/scripts/combine_mkdocs_config_yaml.py theme_common/mkdocs.yml theme_override/mkdocs.yml mkdocs.yml
+	PYTHON=$(abspath $(PY)) bash scripts/pre_build_merge.sh
+	$(PY) -m mkdocs serve
+
+clean: ## Remove fetched repos and generated artifacts (surgical; never `git clean`)
+	rm -rf .suboperators mkdocs.yml dist site
+	@python3 -c "import sys;sys.path.insert(0,'scripts');import merge_docs;[print(o['slug']) for o in merge_docs.load_config('merge.yaml')]" 2>/dev/null \
+	  | while read -r s; do [ -n "$$s" ] && find content -type d -name "$$s" -prune -exec rm -rf {} + 2>/dev/null || true; done

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VENV := .venv
 PY   := $(VENV)/bin/python
 
 .DEFAULT_GOAL := help
-.PHONY: help venv merge serve clean
+.PHONY: help venv test merge serve clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -15,6 +15,10 @@ help: ## Show this help
 venv: ## Create the local virtualenv if missing
 	@test -x $(PY) || python3 -m venv $(VENV)
 	@$(VENV)/bin/pip install -q --upgrade pip
+
+test: venv ## Run the merge_docs unit tests
+	$(VENV)/bin/pip install -q -r requirements-dev.txt
+	$(PY) -m pytest
 
 # Clones the repos in merge.yaml and merges their docs into content/ + mkdocs.yml.
 # Assumes mkdocs.yml already exists (produced by the theme-combine step). This is

--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ this repo's `content/` directory at build time by [`scripts/merge_docs.py`](./sc
   an already-merged nav would duplicate entries. See [`DockerfileLocal`](./DockerfileLocal)
   for the conditional `MERGE_SUBOP_REPOS` gate.
 - A host-side run of `merge_docs.py` copies files directly into the real `content/`
-  tree. To undo it, remove only the specific generated paths listed in `merge.yaml`
-  afterward — do not use a broad `git clean`, which could wipe other untracked work.
+  tree. To undo it, remove only the specific generated paths listed in `merge.yaml` afterward.
 - Production CI performs the build inside the shared `stakater/.github` reusable
   workflow, so wiring up the sub-operator repo clone + merge step there is a
   separate coordination task.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ python3 -m mike serve
 
 Then, you can make changes in `content` or `dist/_theme` folder. Please note that `dist/_theme` is a build folder and any changes made here will be lost if you do not move them to the `theme_common` or the `theme_override` folder.
 
+## Merging sub-operator docs
+
+Some sub-operators maintain their own docs repos, and their content can be merged into
+this repo's `content/` directory at build time by [`scripts/merge_docs.py`](./scripts/merge_docs.py).
+
+- [`merge.yaml`](./merge.yaml) controls which sub-operator repos are merged, which
+  paths are copied, and where each mapping is nested in the nav (`under:`).
+- By default, `docker build -f DockerfileLocal` does not have the sub-operator repos
+  in its build context, so the merge step is skipped and the local build works
+  normally with no extra setup.
+- To include sub-operator docs in a local build: clone the sub-operator repos, make
+  them available to the build (e.g. via `docker build --build-context`), and pass
+  `--build-arg MERGE_SUBOP_REPOS="template-operator=/path hibernation-operator=/path"`
+  (space-separated `slug=path` pairs). Alternatively, run
+  `python scripts/merge_docs.py --set-repo slug=path ...` on the host as a
+  pre-build step, then build normally.
+- The merge must run against a freshly combined `mkdocs.yml` (i.e. after
+  `combine_mkdocs_config_yaml.py` and before `mkdocs build`) — re-running it against
+  an already-merged nav would duplicate entries. See [`DockerfileLocal`](./DockerfileLocal)
+  for the conditional `MERGE_SUBOP_REPOS` gate.
+- A host-side run of `merge_docs.py` copies files directly into the real `content/`
+  tree. To undo it, remove only the specific generated paths listed in `merge.yaml`
+  afterward — do not use a broad `git clean`, which could wipe other untracked work.
+- Production CI performs the build inside the shared `stakater/.github` reusable
+  workflow, so wiring up the sub-operator repo clone + merge step there is a
+  separate coordination task.
+
 ### QA Checks
 
 You can run QA checks locally. They are also run as part of pull request builds.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "scripts"))

--- a/merge.yaml
+++ b/merge.yaml
@@ -14,21 +14,15 @@ operators:
     live_url: https://docs.stakater.com/template-operator-docs/
     live_url_style: directory
     mappings:
-      # - from: "overview/**"
-      #   into: "overview"
-      #   under: "Overview"
-      # - from: "concepts/**"
-      #   into: "concepts"
-      #   under: "Architecture"
-      # - from: "getting-started/**"
-      #   into: "getting-started"
-      #   under: "Install"
-      - from: "guides/**"
-        into: "guides"
-        under: "Guides"
-      - from: "reference/**"
+      - from: "reference/api.md"        # single file, one custom-named entry
         into: "kubernetes-resources"
         under: "API Reference"
+        title: "Templates"
+        flatten: true
+      - from: "guides/**"               # merged flat into the Guides section
+        into: "guides"
+        under: "Guides"
+        flatten: true
       - from: "images/**"
         into: "images"          # assets only, no menu entry
     exclude:
@@ -40,24 +34,18 @@ operators:
     live_url: https://docs.stakater.com/hibernation-operator-docs/
     live_url_style: html          # sub-op uses use_directory_urls: false
     mappings:
-      # - from: "overview/**"
-      #   into: "overview"
-      #   under: "Overview"
-      # - from: "concepts/**"
-      #   into: "concepts"
-      #   under: "Architecture"
-      # - from: "getting-started/**"
-      #   into: "getting-started"
-      #   under: "Install"
-      - from: "guides/**"
-        into: "guides"
-        under: "Guides"
-      - from: "reference/**"
+      - from: "reference/api/**"        # the CRD API pages, merged flat
         into: "kubernetes-resources"
         under: "API Reference"
-      - from: "integrations/**"
+        flatten: true
+      - from: "guides/**"               # merged flat into the Guides section
+        into: "guides"
+        under: "Guides"
+        flatten: true
+      - from: "integrations/**"        # merged flat into the Extensions section
         into: "integrations"
         under: "Extensions"
+        flatten: true
       - from: "images/**"
         into: "images"
     exclude:

--- a/merge.yaml
+++ b/merge.yaml
@@ -7,7 +7,7 @@
 # migrated to the shared structure (structure.md), these become near 1:1 pairs
 # (guides->Guides, reference->Reference, concepts->Concepts, ...).
 operators:
-  - title: Template Operator
+  - title: Template
     repo: https://github.com/stakater/template-operator-docs.git
     # links to pages NOT whitelisted below fall back to this published site
     live_url: https://docs.stakater.com/template-operator-docs/
@@ -33,7 +33,7 @@ operators:
     exclude:
       - "**/.gitkeep"
 
-  - title: Hibernation Operator
+  - title: Hibernation
     repo: https://github.com/stakater/hibernation-operator-docs.git
     live_url: https://docs.stakater.com/hibernation-operator-docs/
     live_url_style: html          # sub-op uses use_directory_urls: false

--- a/merge.yaml
+++ b/merge.yaml
@@ -1,0 +1,57 @@
+# Controls which sub-operator docs are merged into mto-docs at build time.
+# `repo` is the canonical source (git URL); the pipeline clones it and the
+# merge runs against the clone via --set-repo. Locally, override with --set-repo
+# (see the Makefile) to point at a local checkout.
+#
+# NOTE: `into`/`under` target the CURRENT mto-docs nav/layout. Once mto-docs is
+# migrated to the shared structure (structure.md), these become near 1:1 pairs
+# (guides->Guides, reference->Reference, concepts->Concepts, ...).
+operators:
+  - title: Template Operator
+    repo: https://github.com/stakater/template-operator-docs.git
+    mappings:
+      - from: "overview/**"
+        into: "overview"
+        under: "Overview"
+      - from: "concepts/**"
+        into: "concepts"
+        under: "Architecture"
+      - from: "getting-started/**"
+        into: "getting-started"
+        under: "Install"
+      - from: "guides/**"
+        into: "guides"
+        under: "Guides"
+      - from: "reference/**"
+        into: "reference"
+        under: "API Reference"
+      - from: "images/**"
+        into: "images"          # assets only, no menu entry
+    exclude:
+      - "**/.gitkeep"
+
+  - title: Hibernation Operator
+    repo: https://github.com/stakater/hibernation-operator-docs.git
+    mappings:
+      - from: "overview/**"
+        into: "overview"
+        under: "Overview"
+      - from: "concepts/**"
+        into: "concepts"
+        under: "Architecture"
+      - from: "getting-started/**"
+        into: "getting-started"
+        under: "Install"
+      - from: "guides/**"
+        into: "guides"
+        under: "Guides"
+      - from: "reference/**"
+        into: "reference"
+        under: "API Reference"
+      - from: "integrations/**"
+        into: "integrations"
+        under: "Extensions"
+      - from: "images/**"
+        into: "images"
+    exclude:
+      - "**/.gitkeep"

--- a/merge.yaml
+++ b/merge.yaml
@@ -9,16 +9,19 @@
 operators:
   - title: Template Operator
     repo: https://github.com/stakater/template-operator-docs.git
+    # links to pages NOT whitelisted below fall back to this published site
+    live_url: https://docs.stakater.com/template-operator-docs/
+    live_url_style: directory
     mappings:
-      - from: "overview/**"
-        into: "overview"
-        under: "Overview"
-      - from: "concepts/**"
-        into: "concepts"
-        under: "Architecture"
-      - from: "getting-started/**"
-        into: "getting-started"
-        under: "Install"
+      # - from: "overview/**"
+      #   into: "overview"
+      #   under: "Overview"
+      # - from: "concepts/**"
+      #   into: "concepts"
+      #   under: "Architecture"
+      # - from: "getting-started/**"
+      #   into: "getting-started"
+      #   under: "Install"
       - from: "guides/**"
         into: "guides"
         under: "Guides"
@@ -32,16 +35,18 @@ operators:
 
   - title: Hibernation Operator
     repo: https://github.com/stakater/hibernation-operator-docs.git
+    live_url: https://docs.stakater.com/hibernation-operator-docs/
+    live_url_style: html          # sub-op uses use_directory_urls: false
     mappings:
-      - from: "overview/**"
-        into: "overview"
-        under: "Overview"
-      - from: "concepts/**"
-        into: "concepts"
-        under: "Architecture"
-      - from: "getting-started/**"
-        into: "getting-started"
-        under: "Install"
+      # - from: "overview/**"
+      #   into: "overview"
+      #   under: "Overview"
+      # - from: "concepts/**"
+      #   into: "concepts"
+      #   under: "Architecture"
+      # - from: "getting-started/**"
+      #   into: "getting-started"
+      #   under: "Install"
       - from: "guides/**"
         into: "guides"
         under: "Guides"

--- a/merge.yaml
+++ b/merge.yaml
@@ -9,6 +9,7 @@
 operators:
   - title: Template
     repo: https://github.com/stakater/template-operator-docs.git
+    # branch: main            # optional; empty -> the repo's default branch
     # links to pages NOT whitelisted below fall back to this published site
     live_url: https://docs.stakater.com/template-operator-docs/
     live_url_style: directory
@@ -35,6 +36,7 @@ operators:
 
   - title: Hibernation
     repo: https://github.com/stakater/hibernation-operator-docs.git
+    # branch: main            # optional; empty -> the repo's default branch
     live_url: https://docs.stakater.com/hibernation-operator-docs/
     live_url_style: html          # sub-op uses use_directory_urls: false
     mappings:

--- a/merge.yaml
+++ b/merge.yaml
@@ -23,7 +23,7 @@ operators:
         into: "guides"
         under: "Guides"
       - from: "reference/**"
-        into: "reference"
+        into: "kubernetes-resources"
         under: "API Reference"
       - from: "images/**"
         into: "images"          # assets only, no menu entry
@@ -46,7 +46,7 @@ operators:
         into: "guides"
         under: "Guides"
       - from: "reference/**"
-        into: "reference"
+        into: "kubernetes-resources"
         under: "API Reference"
       - from: "integrations/**"
         into: "integrations"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+PyYAML>=6.0
+pytest>=8.0

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -144,14 +144,17 @@ def nav_folder_titles(nav):
         for item in items:
             if isinstance(item, dict):
                 for title, val in item.items():
-                    if isinstance(val, list):
-                        files = _collect_files(val)
-                        if files:
-                            common = (posixpath.dirname(files[0]) if len(files) == 1
-                                      else posixpath.commonpath(files))
-                            if common:
-                                titles.setdefault(common, title)
-                        walk(val)
+                    if not isinstance(val, list):
+                        continue
+                    # recurse first so a deeper (more specific) section claims the
+                    # folder; a broad ancestor then won't override it (setdefault)
+                    walk(val)
+                    files = _collect_files(val)
+                    if files:
+                        common = (posixpath.dirname(files[0]) if len(files) == 1
+                                  else posixpath.commonpath(files))
+                        if common:
+                            titles.setdefault(common, title)
 
     walk(nav)
     return titles

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -5,6 +5,7 @@ Driven by merge.yaml. Runs after the mkdocs config-combine step and before
 """
 import argparse
 import fnmatch
+import posixpath
 import re
 import shutil
 import sys
@@ -189,6 +190,62 @@ def load_config(path):
     return operators
 
 
+_INLINE_LINK_RE = re.compile(r"(!?\[[^\]]*\]\()([^)]+)(\))")
+_REF_LINK_RE = re.compile(r"(?m)^([ \t]*\[[^\]]+\]:[ \t]+)(\S+)(.*)$")
+
+
+def _split_url_title(target):
+    """Split a link target into (url, title) where title includes its quotes."""
+    s = target.strip()
+    title = ""
+    mo = re.match(r'^(.*?)(\s+(?:"[^"]*"|\'[^\']*\'))\s*$', s)
+    if mo:
+        s, title = mo.group(1).strip(), mo.group(2).strip()
+    if s.startswith("<") and s.endswith(">"):
+        s = s[1:-1]
+    return s, title
+
+
+def _rewrite_url(url, src_dir, dest_dir, mapping):
+    """Rewrite one relative link so it still resolves after relocation."""
+    if not url or url[0] in "#/" or "://" in url or url.startswith("mailto:"):
+        return url
+    mo = re.match(r"^([^#?]*)([#?].*)?$", url)
+    path_part, frag = mo.group(1), mo.group(2) or ""
+    if not path_part:
+        return url
+    resolved = posixpath.normpath(posixpath.join(src_dir, path_part))
+    if resolved in mapping:
+        return posixpath.relpath(mapping[resolved], dest_dir or ".") + frag
+    return url
+
+
+def rewrite_links(text, src_rel, dest_rel, mapping):
+    """Rewrite intra-merge relative links/images in a moved markdown file.
+
+    `mapping` maps source-relative paths (as they were in the sub-operator repo)
+    to their new content-relative destinations. Links resolving to a file in the
+    map are rewritten relative to the moved file; everything else is untouched.
+    """
+    src_dir = posixpath.dirname(src_rel)
+    dest_dir = posixpath.dirname(dest_rel)
+
+    def _inline(m):
+        url, title = _split_url_title(m.group(2))
+        new = _rewrite_url(url, src_dir, dest_dir, mapping)
+        if new == url:
+            return m.group(0)
+        return m.group(1) + new + (" " + title if title else "") + m.group(3)
+
+    def _ref(m):
+        new = _rewrite_url(m.group(2), src_dir, dest_dir, mapping)
+        return m.group(1) + new + m.group(3)
+
+    text = _INLINE_LINK_RE.sub(_inline, text)
+    text = _REF_LINK_RE.sub(_ref, text)
+    return text
+
+
 def run(operators, content_dir, mkdocs_path, repo_overrides=None):
     content_dir = Path(content_dir)
     overrides = repo_overrides or {}
@@ -203,6 +260,8 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
             raise FileNotFoundError(f"docs dir not found: {docs}")
 
         under_entries = {}
+        op_map = {}       # source-relative path -> content-relative destination
+        md_files = []     # (src_rel, dest_rel) of copied markdown, for link rewriting
         for mapping in op["mappings"]:
             base = glob_base(mapping["from"])
             matches = find_matches(docs, mapping["from"], op["exclude"])
@@ -214,11 +273,23 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
                 if dest_rel in seen:
                     raise ValueError(f"destination collision: {dest_rel}")
                 seen[dest_rel] = True
+                op_map[rel] = dest_rel
                 dest = content_dir / dest_rel
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(docs / rel, dest)
-                if mapping.get("under"):
-                    under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel))
+                # only markdown pages become nav entries; assets are copied only
+                if rel.endswith(".md"):
+                    md_files.append((rel, dest_rel))
+                    if mapping.get("under"):
+                        under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel))
+
+        # rewrite intra-operator relative links now that all destinations are known
+        for src_rel, dest_rel in md_files:
+            dest = content_dir / dest_rel
+            original = dest.read_text(encoding="utf-8")
+            updated = rewrite_links(original, src_rel, dest_rel, op_map)
+            if updated != original:
+                dest.write_text(updated, encoding="utf-8")
 
         for under, entries in under_entries.items():
             insert_subtree(nav, under, op["title"], build_nav_tree(entries))

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -1,6 +1,7 @@
 """Merge sub-operator docs into the mto-docs content tree and nav.
 
 Driven by merge.yaml. Runs after the mkdocs config-combine step and before
+`mkdocs build`. See docs/superpowers/specs/2026-07-03-merge-sub-operator-docs-design.md.
 """
 import argparse
 import fnmatch
@@ -253,6 +254,7 @@ def load_config(path):
         operators.append({
             "title": raw["title"],
             "repo": raw["repo"],
+            "branch": raw.get("branch") or "",   # empty -> repo default branch
             "slug": raw.get("slug") or slugify(raw["title"]),
             "docs_dir": raw.get("docs_dir", "content"),
             "exclude": raw.get("exclude") or [],

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -137,11 +137,16 @@ def _nav_bounds(text):
         raise ValueError("no top-level 'nav:' block found in mkdocs.yml")
     end = len(lines)
     for j in range(start + 1, len(lines)):
-        if lines[j].strip() == "":
+        line = lines[j]
+        if line.strip() == "":
             continue
-        if not lines[j][0].isspace():
-            end = j
-            break
+        # Indented lines and column-0 list items ("- ...", as PyYAML emits
+        # sequences under a mapping key) belong to the nav block. The block
+        # ends only at the next top-level mapping key.
+        if line[0].isspace() or line[0] == "-":
+            continue
+        end = j
+        break
     return lines, start, end
 
 

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -46,7 +46,9 @@ def strip_base(rel, base):
     return rel[len(prefix):]
 
 
-def compute_dest(remainder, into, slug):
+def compute_dest(remainder, into, slug, flatten=False):
+    if flatten:   # keep slug (namespacing), drop sub-dirs: into/<slug>/<basename>
+        return "/".join(p for p in (into, slug, remainder.rsplit("/", 1)[-1]) if p)
     return "/".join(p for p in (into, slug, remainder) if p)
 
 
@@ -197,6 +199,18 @@ def insert_subtree(nav, under, title, subtree):
             item[title].extend(subtree)
             return
     section.append({title: subtree})
+
+
+def insert_leaves(nav, under, leaves):
+    """Append leaf nav entries directly into the `under` section (flatten mode).
+
+    No operator wrapper folder: each leaf (a bare dest string or a {title: dest}
+    dict) becomes a direct child of the target section.
+    """
+    section = find_section(nav, under)
+    if section is None:
+        raise KeyError(f"menu section {under!r} not found in nav")
+    section.extend(leaves)
 
 
 def _nav_bounds(text):
@@ -361,6 +375,7 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
 
         folder_titles = read_folder_titles(repo)   # from the sub-op's own nav
         under_entries = {}
+        flat_leaves = []  # (under, leaf-entry) for flatten mappings, in nav order
         op_map = {}       # source-relative path -> content-relative destination
         md_files = []     # (src_rel, dest_rel) of copied markdown, for link rewriting
         for mapping in op["mappings"]:
@@ -368,9 +383,11 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
             matches = find_matches(docs, mapping["from"], op["exclude"])
             if not matches:
                 raise ValueError(f"{mapping['from']!r} matched no files in {docs}")
+            flatten = mapping.get("flatten", False)
+            mapping_dests = []   # dests of copied .md in this mapping (nav order)
             for rel in matches:
                 remainder = strip_base(rel, base)
-                dest_rel = compute_dest(remainder, mapping["into"], op["slug"])
+                dest_rel = compute_dest(remainder, mapping["into"], op["slug"], flatten)
                 if dest_rel in seen:
                     raise ValueError(f"destination collision: {dest_rel}")
                 seen[dest_rel] = True
@@ -382,7 +399,21 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
                 if rel.endswith(".md"):
                     md_files.append((rel, dest_rel))
                     if mapping.get("under"):
-                        under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel, rel))
+                        if flatten:
+                            mapping_dests.append(dest_rel)
+                        else:
+                            under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel, rel))
+            # flatten: merge as direct leaves under the section (no op wrapper).
+            # A `title` renames a single-file mapping; with several files it names
+            # a folder holding them, else each page keeps its own H1 as the label.
+            if flatten and mapping_dests:
+                title = mapping.get("title")
+                if title and len(mapping_dests) == 1:
+                    flat_leaves.append((mapping["under"], {title: mapping_dests[0]}))
+                elif title:
+                    flat_leaves.append((mapping["under"], {title: mapping_dests}))
+                else:
+                    flat_leaves.extend((mapping["under"], d) for d in mapping_dests)
 
         # rewrite links now that all destinations are known: whitelisted targets
         # become local, everything else falls back to the operator's live docs
@@ -404,6 +435,8 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
 
         for under, entries in under_entries.items():
             insert_subtree(nav, under, op["title"], build_nav_tree(entries, folder_titles))
+        for under, leaf in flat_leaves:
+            insert_leaves(nav, under, [leaf])
 
     Path(mkdocs_path).write_text(write_nav(text, nav))
 

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -1,0 +1,248 @@
+"""Merge sub-operator docs into the mto-docs content tree and nav.
+
+Driven by merge.yaml. Runs after the mkdocs config-combine step and before
+`mkdocs build`. See docs/superpowers/specs/2026-07-03-merge-sub-operator-docs-design.md.
+"""
+import argparse
+import fnmatch
+import re
+import shutil
+import sys
+import yaml
+from pathlib import Path
+
+_WILDCARD = set("*?[]")
+
+
+def slugify(title):
+    s = re.sub(r"[^a-z0-9]+", "-", title.lower())
+    return s.strip("-")
+
+
+def prettify(name):
+    return " ".join(w.capitalize() for w in re.split(r"[-_\s]+", name) if w)
+
+
+def glob_base(pattern):
+    parts = pattern.split("/")
+    base = []
+    for p in parts:
+        if any(c in _WILDCARD for c in p):
+            break
+        base.append(p)
+    if len(base) == len(parts):   # no wildcard -> drop the file component
+        base = base[:-1]
+    return "/".join(base)
+
+
+def strip_base(rel, base):
+    if not base:
+        return rel
+    prefix = base + "/"
+    if not rel.startswith(prefix):
+        raise ValueError(f"{rel!r} not under base {base!r}")
+    return rel[len(prefix):]
+
+
+def compute_dest(remainder, into, slug):
+    return "/".join(p for p in (into, slug, remainder) if p)
+
+
+def _excluded(rel, patterns):
+    name = rel.rsplit("/", 1)[-1]
+    for ex in patterns:
+        if fnmatch.fnmatch(rel, ex) or fnmatch.fnmatch(name, ex.replace("**/", "")):
+            return True
+    return False
+
+
+def find_matches(docs_dir, pattern, exclude):
+    glob_pat = pattern + "/*" if pattern.endswith("**") else pattern
+    results = []
+    for p in docs_dir.glob(glob_pat):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(docs_dir).as_posix()
+        if _excluded(rel, exclude or []):
+            continue
+        results.append(rel)
+    return sorted(results)
+
+
+def build_nav_tree(entries):
+    root = {}
+    for remainder, full in sorted(entries):
+        parts = remainder.split("/")
+        node = root
+        for i, folder in enumerate(parts[:-1]):
+            existing = node.get(folder)
+            if existing is not None and not isinstance(existing, dict):
+                raise ValueError(
+                    f"nav conflict: {'/'.join(parts[:i + 1])!r} is used as both a file and a folder"
+                )
+            node = node.setdefault(folder, {})
+        leaf = parts[-1]
+        if leaf in node:
+            if isinstance(node[leaf], dict):
+                raise ValueError(
+                    f"nav conflict: {remainder!r} is used as both a file and a folder"
+                )
+            raise ValueError(f"duplicate nav entry for remainder {remainder!r}")
+        node[leaf] = full
+    return _to_nav(root)
+
+
+def _to_nav(node):
+    out = []
+    for key, val in node.items():
+        if isinstance(val, dict):
+            out.append({prettify(key): _to_nav(val)})
+        else:
+            out.append(val)
+    return out
+
+
+def find_section(nav, title):
+    for item in nav:
+        if isinstance(item, dict):
+            for key, val in item.items():
+                if key == title and isinstance(val, list):
+                    return val
+                if isinstance(val, list):
+                    found = find_section(val, title)
+                    if found is not None:
+                        return found
+    return None
+
+
+def insert_subtree(nav, under, title, subtree):
+    section = find_section(nav, under)
+    if section is None:
+        raise KeyError(f"menu section {under!r} not found in nav")
+    for item in section:
+        if isinstance(item, dict) and title in item and isinstance(item[title], list):
+            item[title].extend(subtree)
+            return
+    section.append({title: subtree})
+
+
+def _nav_bounds(text):
+    lines = text.splitlines(keepends=True)
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^nav\s*:", line):
+            start = i
+            break
+    if start is None:
+        raise ValueError("no top-level 'nav:' block found in mkdocs.yml")
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].strip() == "":
+            continue
+        if not lines[j][0].isspace():
+            end = j
+            break
+    return lines, start, end
+
+
+def read_nav(text):
+    lines, start, end = _nav_bounds(text)
+    block = "".join(lines[start:end])
+    return yaml.safe_load(block)["nav"]
+
+
+def write_nav(text, nav):
+    lines, start, end = _nav_bounds(text)
+    block = yaml.safe_dump({"nav": nav}, sort_keys=False, allow_unicode=True,
+                           default_flow_style=False)
+    # Indent all lines except the first (nav:) with 2 spaces to match mkdocs.yml style
+    block_lines = block.split('\n')
+    indented = [block_lines[0]]
+    for line in block_lines[1:]:
+        if line:  # Don't indent empty lines
+            indented.append('  ' + line)
+        else:
+            indented.append(line)
+    block = '\n'.join(indented)
+    if not block.endswith("\n"):
+        block += "\n"
+    return "".join(lines[:start]) + block + "".join(lines[end:])
+
+
+def load_config(path):
+    data = yaml.safe_load(Path(path).read_text())
+    operators = []
+    for raw in data["operators"]:
+        operators.append({
+            "title": raw["title"],
+            "repo": raw["repo"],
+            "slug": raw.get("slug") or slugify(raw["title"]),
+            "docs_dir": raw.get("docs_dir", "content"),
+            "exclude": raw.get("exclude") or [],
+            "mappings": raw["mappings"],
+        })
+    return operators
+
+
+def run(operators, content_dir, mkdocs_path, repo_overrides=None):
+    content_dir = Path(content_dir)
+    overrides = repo_overrides or {}
+    text = Path(mkdocs_path).read_text()
+    nav = read_nav(text)
+    seen = {}
+
+    for op in operators:
+        repo = Path(overrides.get(op["slug"], op["repo"]))
+        docs = repo / op["docs_dir"]
+        if not docs.is_dir():
+            raise FileNotFoundError(f"docs dir not found: {docs}")
+
+        under_entries = {}
+        for mapping in op["mappings"]:
+            base = glob_base(mapping["from"])
+            matches = find_matches(docs, mapping["from"], op["exclude"])
+            if not matches:
+                raise ValueError(f"{mapping['from']!r} matched no files in {docs}")
+            for rel in matches:
+                remainder = strip_base(rel, base)
+                dest_rel = compute_dest(remainder, mapping["into"], op["slug"])
+                if dest_rel in seen:
+                    raise ValueError(f"destination collision: {dest_rel}")
+                seen[dest_rel] = True
+                dest = content_dir / dest_rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(docs / rel, dest)
+                if mapping.get("under"):
+                    under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel))
+
+        for under, entries in under_entries.items():
+            insert_subtree(nav, under, op["title"], build_nav_tree(entries))
+
+    Path(mkdocs_path).write_text(write_nav(text, nav))
+
+
+def parse_repo_overrides(pairs):
+    out = {}
+    for pair in pairs:
+        slug, _, path = pair.partition("=")
+        if not slug or not path:
+            raise ValueError(f"--set-repo expects slug=path, got {pair!r}")
+        out[slug] = path
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Merge sub-operator docs into mto-docs.")
+    ap.add_argument("--config", default="merge.yaml")
+    ap.add_argument("--content-dir", default="content")
+    ap.add_argument("--mkdocs", default="mkdocs.yml")
+    ap.add_argument("--set-repo", action="append", default=[], metavar="slug=path")
+    args = ap.parse_args(argv)
+    operators = load_config(args.config)
+    overrides = parse_repo_overrides(args.set_repo)
+    run(operators, args.content_dir, args.mkdocs, overrides)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -1,7 +1,6 @@
 """Merge sub-operator docs into the mto-docs content tree and nav.
 
 Driven by merge.yaml. Runs after the mkdocs config-combine step and before
-`mkdocs build`. See docs/superpowers/specs/2026-07-03-merge-sub-operator-docs-design.md.
 """
 import argparse
 import fnmatch

--- a/scripts/merge_docs.py
+++ b/scripts/merge_docs.py
@@ -21,6 +21,7 @@ def slugify(title):
 
 
 def prettify(name):
+    """Fallback folder title when the sub-operator's nav has no name for it."""
     return " ".join(w.capitalize() for w in re.split(r"[-_\s]+", name) if w)
 
 
@@ -70,12 +71,22 @@ def find_matches(docs_dir, pattern, exclude):
     return sorted(results)
 
 
-def build_nav_tree(entries):
+def build_nav_tree(entries, folder_titles=None):
+    """Build a nested nav list from (remainder, dest, src) entries.
+
+    Folder node labels come from `folder_titles` (source-folder-path -> title,
+    taken from the sub-operator's own nav) when available, else `prettify`.
+    """
+    folder_titles = folder_titles or {}
     root = {}
-    for remainder, full in sorted(entries):
+    src_of = {}   # remainder-prefix -> source folder path (to look up its title)
+    for remainder, dest, src in sorted(entries):
         parts = remainder.split("/")
+        src_parts = src.split("/")
+        base_len = len(src_parts) - len(parts)   # leading src comps stripped in remainder
         node = root
         for i, folder in enumerate(parts[:-1]):
+            src_of["/".join(parts[:i + 1])] = "/".join(src_parts[:base_len + i + 1])
             existing = node.get(folder)
             if existing is not None and not isinstance(existing, dict):
                 raise ValueError(
@@ -89,18 +100,76 @@ def build_nav_tree(entries):
                     f"nav conflict: {remainder!r} is used as both a file and a folder"
                 )
             raise ValueError(f"duplicate nav entry for remainder {remainder!r}")
-        node[leaf] = full
-    return _to_nav(root)
+        node[leaf] = dest
+    return _to_nav(root, "", src_of, folder_titles)
 
 
-def _to_nav(node):
+def _to_nav(node, prefix, src_of, folder_titles):
     out = []
     for key, val in node.items():
         if isinstance(val, dict):
-            out.append({prettify(key): _to_nav(val)})
+            child_prefix = f"{prefix}/{key}" if prefix else key
+            title = folder_titles.get(src_of.get(child_prefix, "")) or prettify(key)
+            out.append({title: _to_nav(val, child_prefix, src_of, folder_titles)})
         else:
             out.append(val)
     return out
+
+
+def _collect_files(items):
+    """All file-path strings reachable under a nav item list."""
+    out = []
+    for item in items:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            for val in item.values():
+                if isinstance(val, list):
+                    out.extend(_collect_files(val))
+                elif isinstance(val, str):
+                    out.append(val)
+    return out
+
+
+def nav_folder_titles(nav):
+    """Map source folder path -> title, derived from a sub-operator's own nav.
+
+    Each titled section is mapped to the common directory of the files beneath
+    it, so e.g. a section 'API Reference' over reference/api/*.md yields
+    {'reference/api': 'API Reference'}.
+    """
+    titles = {}
+
+    def walk(items):
+        for item in items:
+            if isinstance(item, dict):
+                for title, val in item.items():
+                    if isinstance(val, list):
+                        files = _collect_files(val)
+                        if files:
+                            common = (posixpath.dirname(files[0]) if len(files) == 1
+                                      else posixpath.commonpath(files))
+                            if common:
+                                titles.setdefault(common, title)
+                        walk(val)
+
+    walk(nav)
+    return titles
+
+
+def read_folder_titles(repo):
+    """Read a sub-operator repo's own nav and return source-folder -> title."""
+    for candidate in ("theme_override/mkdocs.yml", "mkdocs.yml"):
+        path = repo / candidate
+        if not path.is_file():
+            continue
+        try:
+            nav = read_nav(path.read_text(encoding="utf-8"))
+        except (ValueError, KeyError, TypeError):
+            continue
+        if nav:
+            return nav_folder_titles(nav)
+    return {}
 
 
 def find_section(nav, title):
@@ -185,6 +254,8 @@ def load_config(path):
             "slug": raw.get("slug") or slugify(raw["title"]),
             "docs_dir": raw.get("docs_dir", "content"),
             "exclude": raw.get("exclude") or [],
+            "live_url": raw.get("live_url"),
+            "live_url_style": raw.get("live_url_style", "directory"),
             "mappings": raw["mappings"],
         })
     return operators
@@ -206,8 +277,25 @@ def _split_url_title(target):
     return s, title
 
 
-def _rewrite_url(url, src_dir, dest_dir, mapping):
-    """Rewrite one relative link so it still resolves after relocation."""
+def _to_live_url(path, live_url, style):
+    """Map a source-relative path to a URL on the operator's published site."""
+    base = live_url if live_url.endswith("/") else live_url + "/"
+    if path.endswith(".md"):
+        stem = path[:-3]
+        if style == "html":
+            suffix = stem + ".html"
+        elif stem == "index":
+            suffix = ""
+        elif stem.endswith("/index"):
+            suffix = stem[: -len("index")]   # keep the trailing slash
+        else:
+            suffix = stem + "/"
+        return base + suffix
+    return base + path   # assets keep their path
+
+
+def _rewrite_url(url, src_dir, dest_dir, mapping, live_url, style, external):
+    """Whitelisted target -> local relative link; otherwise -> live_url fallback."""
     if not url or url[0] in "#/" or "://" in url or url.startswith("mailto:"):
         return url
     mo = re.match(r"^([^#?]*)([#?].*)?$", url)
@@ -217,33 +305,41 @@ def _rewrite_url(url, src_dir, dest_dir, mapping):
     resolved = posixpath.normpath(posixpath.join(src_dir, path_part))
     if resolved in mapping:
         return posixpath.relpath(mapping[resolved], dest_dir or ".") + frag
+    # not whitelisted: fall back to the operator's live docs, if configured
+    if live_url and not resolved.startswith(".."):
+        external.append(resolved)
+        return _to_live_url(resolved, live_url, style) + frag
     return url
 
 
-def rewrite_links(text, src_rel, dest_rel, mapping):
-    """Rewrite intra-merge relative links/images in a moved markdown file.
+def rewrite_links(text, src_rel, dest_rel, mapping, live_url=None,
+                  live_url_style="directory"):
+    """Rewrite links in a moved markdown file.
 
-    `mapping` maps source-relative paths (as they were in the sub-operator repo)
-    to their new content-relative destinations. Links resolving to a file in the
-    map are rewritten relative to the moved file; everything else is untouched.
+    Whitelisted targets (files copied by the merge, present in `mapping`) become
+    local relative links. Any other relative link falls back to `live_url` (the
+    operator's published docs) when provided, else is left unchanged. Anchors are
+    preserved. Returns (new_text, externalized) where `externalized` lists the
+    source paths that were pointed at the live site.
     """
     src_dir = posixpath.dirname(src_rel)
     dest_dir = posixpath.dirname(dest_rel)
+    external = []
 
     def _inline(m):
         url, title = _split_url_title(m.group(2))
-        new = _rewrite_url(url, src_dir, dest_dir, mapping)
+        new = _rewrite_url(url, src_dir, dest_dir, mapping, live_url, live_url_style, external)
         if new == url:
             return m.group(0)
         return m.group(1) + new + (" " + title if title else "") + m.group(3)
 
     def _ref(m):
-        new = _rewrite_url(m.group(2), src_dir, dest_dir, mapping)
+        new = _rewrite_url(m.group(2), src_dir, dest_dir, mapping, live_url, live_url_style, external)
         return m.group(1) + new + m.group(3)
 
     text = _INLINE_LINK_RE.sub(_inline, text)
     text = _REF_LINK_RE.sub(_ref, text)
-    return text
+    return text, external
 
 
 def run(operators, content_dir, mkdocs_path, repo_overrides=None):
@@ -259,6 +355,7 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
         if not docs.is_dir():
             raise FileNotFoundError(f"docs dir not found: {docs}")
 
+        folder_titles = read_folder_titles(repo)   # from the sub-op's own nav
         under_entries = {}
         op_map = {}       # source-relative path -> content-relative destination
         md_files = []     # (src_rel, dest_rel) of copied markdown, for link rewriting
@@ -281,18 +378,28 @@ def run(operators, content_dir, mkdocs_path, repo_overrides=None):
                 if rel.endswith(".md"):
                     md_files.append((rel, dest_rel))
                     if mapping.get("under"):
-                        under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel))
+                        under_entries.setdefault(mapping["under"], []).append((remainder, dest_rel, rel))
 
-        # rewrite intra-operator relative links now that all destinations are known
+        # rewrite links now that all destinations are known: whitelisted targets
+        # become local, everything else falls back to the operator's live docs
+        live_url = op.get("live_url")
+        style = op.get("live_url_style", "directory")
+        externalized = []
         for src_rel, dest_rel in md_files:
             dest = content_dir / dest_rel
             original = dest.read_text(encoding="utf-8")
-            updated = rewrite_links(original, src_rel, dest_rel, op_map)
+            updated, ext = rewrite_links(original, src_rel, dest_rel, op_map, live_url, style)
+            externalized.extend(ext)
             if updated != original:
                 dest.write_text(updated, encoding="utf-8")
+        if externalized:
+            print(f">> {op['title']}: {len(externalized)} link(s) point to live docs "
+                  f"({live_url}); distinct targets:")
+            for target in sorted(set(externalized)):
+                print(f"     {target}")
 
         for under, entries in under_entries.items():
-            insert_subtree(nav, under, op["title"], build_nav_tree(entries))
+            insert_subtree(nav, under, op["title"], build_nav_tree(entries, folder_titles))
 
     Path(mkdocs_path).write_text(write_nav(text, nav))
 

--- a/scripts/pre_build_merge.sh
+++ b/scripts/pre_build_merge.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-build hook for the shared versioned-doc workflow.
+#
+# Clones the sub-operator repos listed in merge.yaml and merges their docs into
+# content/ and the combined mkdocs.yml. Must run AFTER prepare_theme(_pr).sh
+# (which produces mkdocs.yml) and BEFORE `mike deploy` (which runs mkdocs build).
+#
+# Auth: if PRE_BUILD_TOKEN is set, it is injected into https clone URLs so
+# private sub-operator repos can be cloned.
+set -euo pipefail
+
+CONFIG="${1:-merge.yaml}"
+WORKDIR=".suboperators"
+PYTHON="${PYTHON:-python3}"
+mkdir -p "$WORKDIR"
+
+set_args=()
+while read -r slug repo; do
+  [ -z "$slug" ] && continue
+  dest="$WORKDIR/$slug"
+  url="$repo"
+  # inject token for https URLs (skip ssh/local paths)
+  # if [ -n "${PRE_BUILD_TOKEN:-}" ] && [ "${repo#https://}" != "$repo" ]; then
+  #   url="https://x-access-token:${PRE_BUILD_TOKEN}@${repo#https://}"
+  # fi
+  echo ">> cloning $slug"
+  rm -rf "$dest"
+  git clone --depth 1 "$url" "$dest"
+  set_args+=(--set-repo "$slug=$dest")
+done < <("$PYTHON" -c "import sys; sys.path.insert(0,'scripts'); import merge_docs; [print(op['slug'], op['repo']) for op in merge_docs.load_config('$CONFIG')]")
+
+echo ">> merging sub-operator docs"
+"$PYTHON" scripts/merge_docs.py --config "$CONFIG" "${set_args[@]}"
+echo ">> pre-build merge complete"

--- a/scripts/pre_build_merge.sh
+++ b/scripts/pre_build_merge.sh
@@ -15,7 +15,7 @@ PYTHON="${PYTHON:-python3}"
 mkdir -p "$WORKDIR"
 
 set_args=()
-while read -r slug repo; do
+while IFS=$'\t' read -r slug repo branch; do
   [ -z "$slug" ] && continue
   dest="$WORKDIR/$slug"
   url="$repo"
@@ -23,11 +23,14 @@ while read -r slug repo; do
   # if [ -n "${PRE_BUILD_TOKEN:-}" ] && [ "${repo#https://}" != "$repo" ]; then
   #   url="https://x-access-token:${PRE_BUILD_TOKEN}@${repo#https://}"
   # fi
-  echo ">> cloning $slug"
+  # empty branch -> clone the repo's default branch
+  branch_arg=()
+  [ -n "$branch" ] && branch_arg=(--branch "$branch")
+  echo ">> cloning $slug${branch:+ (branch $branch)}"
   rm -rf "$dest"
-  git clone --depth 1 "$url" "$dest"
+  git clone --depth 1 "${branch_arg[@]}" "$url" "$dest"
   set_args+=(--set-repo "$slug=$dest")
-done < <("$PYTHON" -c "import sys; sys.path.insert(0,'scripts'); import merge_docs; [print(op['slug'], op['repo']) for op in merge_docs.load_config('$CONFIG')]")
+done < <("$PYTHON" -c "import sys; sys.path.insert(0,'scripts'); import merge_docs; [print(op['slug'], op['repo'], op['branch'], sep='\t') for op in merge_docs.load_config('$CONFIG')]")
 
 echo ">> merging sub-operator docs"
 "$PYTHON" scripts/merge_docs.py --config "$CONFIG" "${set_args[@]}"

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -57,6 +57,18 @@ def test_compute_dest():
         "kubernetes-resources/template-operator/how-to/copy.md"
 
 
+def test_compute_dest_flatten_keeps_slug_drops_subdirs():
+    # flatten: into/<slug>/<basename> -- slug kept for collision-safe namespacing,
+    # sub-folders dropped
+    assert m.compute_dest("api.md", "kubernetes-resources", "template", flatten=True) == \
+        "kubernetes-resources/template/api.md"
+    assert m.compute_dest("api/resource-supervisor.md", "kubernetes-resources", "hib",
+                          flatten=True) == "kubernetes-resources/hib/resource-supervisor.md"
+    # non-flatten keeps slug + full structure (default)
+    assert m.compute_dest("api/rs.md", "kubernetes-resources", "hib") == \
+        "kubernetes-resources/hib/api/rs.md"
+
+
 def test_build_nav_tree_nests_folders():
     # entries: (remainder, dest, src)
     entries = [
@@ -172,6 +184,22 @@ def test_insert_subtree_missing_section_raises():
     nav = _sample_nav()
     with pytest.raises(KeyError):
         m.insert_subtree(nav, "Ghost", "Template Operator", ["a/b.md"])
+
+
+def test_insert_leaves_appends_directly():
+    nav = _sample_nav()
+    m.insert_leaves(nav, "API Reference", [{"Templates": "k/api.md"}, "k/rs.md"])
+    assert nav[1] == {"API Reference": [
+        "kubernetes-resources/quota.md",
+        {"Templates": "k/api.md"},
+        "k/rs.md",
+    ]}
+
+
+def test_insert_leaves_missing_section_raises():
+    nav = _sample_nav()
+    with pytest.raises(KeyError):
+        m.insert_leaves(nav, "Ghost", ["a/b.md"])
 
 
 _MKDOCS = """\
@@ -381,6 +409,45 @@ def test_run_copies_files_and_injects_nav(tmp_path):
     assert (content / "kubernetes-resources/template-operator/how-to/copy.md").is_file()
     node = m.find_section(m.read_nav(mkdocs.read_text()), "Template Operator")
     assert "kubernetes-resources/template-operator/template.md" in node
+
+
+def test_run_flatten_single_file_title_and_multi_leaves(tmp_path):
+    repo = tmp_path / "template-operator-docs"
+    _touch(repo / "content",
+           "reference/api.md",
+           "guides/templates/copy.md",
+           "guides/templates/deploy.md")
+    content = tmp_path / "content"; content.mkdir()
+    mkdocs = tmp_path / "mkdocs.yml"
+    mkdocs.write_text(
+        "site_name: MTO\nnav:\n  - API Reference:\n      - k/quota.md\n"
+        "  - Guides:\n      - k/own.md\n"
+    )
+    operators = [{
+        "title": "Template", "repo": str(repo), "slug": "template",
+        "docs_dir": "content", "exclude": [],
+        "mappings": [
+            {"from": "reference/api.md", "into": "kubernetes-resources",
+             "under": "API Reference", "title": "Templates", "flatten": True},
+            {"from": "guides/**", "into": "guides", "under": "Guides", "flatten": True},
+        ],
+    }]
+    m.run(operators, str(content), str(mkdocs))
+
+    # flattened path: slug kept, sub-dirs dropped
+    assert (content / "kubernetes-resources/template/api.md").is_file()
+    assert (content / "guides/template/copy.md").is_file()
+    assert (content / "guides/template/deploy.md").is_file()
+
+    nav = m.read_nav(mkdocs.read_text())
+    # single-file mapping with title -> one renamed leaf, directly under the section
+    assert {"Templates": "kubernetes-resources/template/api.md"} in \
+        m.find_section(nav, "API Reference")
+    # multi-file flatten -> bare dest leaves (mkdocs derives titles from each H1)
+    guides = m.find_section(nav, "Guides")
+    assert "guides/template/copy.md" in guides and "guides/template/deploy.md" in guides
+    # no operator wrapper folder was created
+    assert m.find_section(nav, "Template") is None
 
 
 def test_run_empty_match_raises(tmp_path):

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -124,6 +124,21 @@ def test_nav_folder_titles_from_nav():
     assert titles["guides"] == "Guides"
 
 
+def test_nav_folder_titles_deepest_section_wins():
+    # a broad section whose files all live in one subfolder must NOT claim that
+    # subfolder over the more specific inner section
+    nav = [
+        {"Guides": [
+            {"Templates": [
+                "guides/templates/copying.md",
+                "guides/templates/deploying.md",
+            ]},
+        ]},
+    ]
+    titles = m.nav_folder_titles(nav)
+    assert titles["guides/templates"] == "Templates"   # not "Guides"
+
+
 def _sample_nav():
     return [
         {"Overview": ["index.md"]},

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -161,6 +161,37 @@ def test_read_nav_missing_raises():
         m.read_nav("site_name: x\n")
 
 
+# combine_mkdocs_config_yaml.py emits the merged config via PyYAML, which puts
+# sequence items under a mapping key at column 0 (indentless). read_nav/write_nav
+# must handle that, not just the hand-indented theme_override style above.
+_MKDOCS_COMBINED = (
+    "site_name: MTO\n"
+    "nav:\n"
+    "- Overview:\n"
+    "  - index.md\n"
+    "- API Reference:\n"
+    "  - kubernetes-resources/quota.md\n"
+    "plugins:\n"
+    "- search\n"
+)
+
+
+def test_read_nav_indentless_sequence():
+    nav = m.read_nav(_MKDOCS_COMBINED)
+    assert nav[0] == {"Overview": ["index.md"]}
+    assert m.find_section(nav, "API Reference") == ["kubernetes-resources/quota.md"]
+
+
+def test_write_nav_indentless_preserves_trailing_key():
+    nav = m.read_nav(_MKDOCS_COMBINED)
+    m.insert_subtree(nav, "API Reference", "Template Operator", ["a/b.md"])
+    out = m.write_nav(_MKDOCS_COMBINED, nav)
+    # the key after the nav block must survive untouched
+    assert "plugins:\n- search\n" in out
+    assert out.startswith("site_name: MTO\n")
+    assert m.find_section(m.read_nav(out), "Template Operator") == ["a/b.md"]
+
+
 _CONFIG = """\
 operators:
   - title: Template Operator

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -1,0 +1,261 @@
+import pytest
+import merge_docs as m
+from pathlib import Path
+
+
+def _touch(base, *rels):
+    for r in rels:
+        p = base / r
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x")
+
+
+def test_find_matches_recursive_and_exclude(tmp_path):
+    _touch(tmp_path,
+           "kubernetes-resources/template.md",
+           "kubernetes-resources/how-to/copy.md",
+           "kubernetes-resources/.gitkeep",
+           "images/logo.png")
+    got = m.find_matches(tmp_path, "kubernetes-resources/**", ["**/.gitkeep"])
+    assert got == ["kubernetes-resources/how-to/copy.md",
+                   "kubernetes-resources/template.md"]
+
+
+def test_find_matches_specific_file(tmp_path):
+    _touch(tmp_path, "architecture/logs-metrics.md", "architecture/other.md")
+    assert m.find_matches(tmp_path, "architecture/logs-metrics.md", []) == \
+        ["architecture/logs-metrics.md"]
+
+
+def test_slugify():
+    assert m.slugify("Template Operator") == "template-operator"
+    assert m.slugify("Hibernation  Operator!") == "hibernation-operator"
+
+
+def test_prettify():
+    assert m.prettify("how-to-guides") == "How To Guides"
+    assert m.prettify("reference") == "Reference"
+
+
+def test_glob_base():
+    assert m.glob_base("kubernetes-resources/**") == "kubernetes-resources"
+    assert m.glob_base("kubernetes-resources/how-to-guides/**") == "kubernetes-resources/how-to-guides"
+    assert m.glob_base("architecture/logs-metrics.md") == "architecture"
+    assert m.glob_base("images/**") == "images"
+    assert m.glob_base("index.md") == ""
+
+
+def test_strip_base():
+    assert m.strip_base("kubernetes-resources/template.md", "kubernetes-resources") == "template.md"
+    assert m.strip_base("index.md", "") == "index.md"
+
+
+def test_compute_dest():
+    assert m.compute_dest("template.md", "kubernetes-resources", "template-operator") == \
+        "kubernetes-resources/template-operator/template.md"
+    assert m.compute_dest("how-to/copy.md", "kubernetes-resources", "template-operator") == \
+        "kubernetes-resources/template-operator/how-to/copy.md"
+
+
+def test_build_nav_tree_nests_folders():
+    entries = [
+        ("template.md", "kubernetes-resources/template-operator/template.md"),
+        ("how-to-guides/copy.md", "kubernetes-resources/template-operator/how-to-guides/copy.md"),
+        ("how-to-guides/deploy.md", "kubernetes-resources/template-operator/how-to-guides/deploy.md"),
+    ]
+    assert m.build_nav_tree(entries) == [
+        {"How To Guides": [
+            "kubernetes-resources/template-operator/how-to-guides/copy.md",
+            "kubernetes-resources/template-operator/how-to-guides/deploy.md",
+        ]},
+        "kubernetes-resources/template-operator/template.md",
+    ]
+
+
+def test_build_nav_tree_duplicate_remainder_raises():
+    entries = [
+        ("template.md", "kubernetes-resources/into-a/template.md"),
+        ("template.md", "kubernetes-resources/into-b/template.md"),
+    ]
+    with pytest.raises(ValueError):
+        m.build_nav_tree(entries)
+
+
+def test_build_nav_tree_folder_file_conflict_raises():
+    entries = [
+        ("a", "kubernetes-resources/a"),
+        ("a/b.md", "kubernetes-resources/a/b.md"),
+    ]
+    with pytest.raises(ValueError):
+        m.build_nav_tree(entries)
+
+
+def _sample_nav():
+    return [
+        {"Overview": ["index.md"]},
+        {"API Reference": ["kubernetes-resources/quota.md"]},
+    ]
+
+
+def test_find_section():
+    nav = _sample_nav()
+    assert m.find_section(nav, "API Reference") == ["kubernetes-resources/quota.md"]
+    assert m.find_section(nav, "Nope") is None
+
+
+def test_insert_subtree_appends_title_node():
+    nav = _sample_nav()
+    m.insert_subtree(nav, "API Reference", "Template Operator", ["a/b.md"])
+    assert nav[1] == {"API Reference": [
+        "kubernetes-resources/quota.md",
+        {"Template Operator": ["a/b.md"]},
+    ]}
+
+
+def test_insert_subtree_merges_existing_title():
+    nav = _sample_nav()
+    m.insert_subtree(nav, "API Reference", "Template Operator", ["a/b.md"])
+    m.insert_subtree(nav, "API Reference", "Template Operator", ["a/c.md"])
+    assert nav[1]["API Reference"][1] == {"Template Operator": ["a/b.md", "a/c.md"]}
+
+
+def test_insert_subtree_missing_section_raises():
+    nav = _sample_nav()
+    with pytest.raises(KeyError):
+        m.insert_subtree(nav, "Ghost", "Template Operator", ["a/b.md"])
+
+
+_MKDOCS = """\
+site_name: Multi-Tenant Operator
+markdown_extensions:
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+nav:
+  - Overview:
+      - index.md
+  - API Reference:
+      - kubernetes-resources/quota.md
+plugins:
+  - search
+"""
+
+
+def test_read_nav():
+    nav = m.read_nav(_MKDOCS)
+    assert nav[0] == {"Overview": ["index.md"]}
+
+
+def test_write_nav_preserves_other_lines():
+    nav = m.read_nav(_MKDOCS)
+    m.insert_subtree(nav, "API Reference", "Template Operator", ["a/b.md"])
+    out = m.write_nav(_MKDOCS, nav)
+    # python tag line and plugins block untouched
+    assert "!!python/name:material.extensions.emoji.to_svg" in out
+    assert out.strip().endswith("- search")
+    # new node present and re-parses
+    assert m.find_section(m.read_nav(out), "Template Operator") == ["a/b.md"]
+
+
+def test_read_nav_missing_raises():
+    with pytest.raises(ValueError):
+        m.read_nav("site_name: x\n")
+
+
+_CONFIG = """\
+operators:
+  - title: Template Operator
+    repo: ../template-operator-docs
+    mappings:
+      - from: "kubernetes-resources/**"
+        into: "kubernetes-resources"
+        under: "API Reference"
+  - title: Hibernation Operator
+    repo: ../hibernation-operator-docs
+    slug: hib
+    docs_dir: site
+    exclude: ["**/.gitkeep"]
+    mappings:
+      - from: "guides/**"
+        into: "kubernetes-resources/tenant/how-to-guides"
+        under: "Guides"
+"""
+
+
+def test_load_config_defaults(tmp_path):
+    cfg = tmp_path / "merge.yaml"
+    cfg.write_text(_CONFIG)
+    ops = m.load_config(str(cfg))
+    assert ops[0]["slug"] == "template-operator"
+    assert ops[0]["docs_dir"] == "content"
+    assert ops[0]["exclude"] == []
+    assert ops[1]["slug"] == "hib"
+    assert ops[1]["docs_dir"] == "site"
+    assert ops[1]["exclude"] == ["**/.gitkeep"]
+
+
+def test_run_copies_files_and_injects_nav(tmp_path):
+    # fake sub-operator repo
+    repo = tmp_path / "template-operator-docs"
+    _touch(repo / "content",
+           "kubernetes-resources/template.md",
+           "kubernetes-resources/how-to/copy.md")
+    # mto-docs side
+    content = tmp_path / "content"
+    content.mkdir()
+    mkdocs = tmp_path / "mkdocs.yml"
+    mkdocs.write_text(_MKDOCS)
+
+    operators = [{
+        "title": "Template Operator",
+        "repo": str(repo),
+        "slug": "template-operator",
+        "docs_dir": "content",
+        "exclude": [],
+        "mappings": [{"from": "kubernetes-resources/**",
+                      "into": "kubernetes-resources", "under": "API Reference"}],
+    }]
+    m.run(operators, str(content), str(mkdocs))
+
+    assert (content / "kubernetes-resources/template-operator/template.md").is_file()
+    assert (content / "kubernetes-resources/template-operator/how-to/copy.md").is_file()
+    node = m.find_section(m.read_nav(mkdocs.read_text()), "Template Operator")
+    assert "kubernetes-resources/template-operator/template.md" in node
+
+
+def test_run_empty_match_raises(tmp_path):
+    repo = tmp_path / "repo"
+    _touch(repo / "content", "other/x.md")
+    content = tmp_path / "content"; content.mkdir()
+    mkdocs = tmp_path / "mkdocs.yml"; mkdocs.write_text(_MKDOCS)
+    operators = [{"title": "T", "repo": str(repo), "slug": "t", "docs_dir": "content",
+                  "exclude": [], "mappings": [{"from": "missing/**",
+                  "into": "kubernetes-resources", "under": "API Reference"}]}]
+    with pytest.raises(ValueError):
+        m.run(operators, str(content), str(mkdocs))
+
+
+def test_parse_repo_overrides():
+    assert m.parse_repo_overrides(["template-operator=/a/b", "hib=/c"]) == \
+        {"template-operator": "/a/b", "hib": "/c"}
+
+
+def test_main_end_to_end(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    _touch(repo / "content", "guides/create.md")
+    content = tmp_path / "content"; content.mkdir()
+    mkdocs = tmp_path / "mkdocs.yml"; mkdocs.write_text(_MKDOCS)
+    cfg = tmp_path / "merge.yaml"
+    cfg.write_text(
+        "operators:\n"
+        "  - title: Template Operator\n"
+        "    repo: /nonexistent\n"
+        "    mappings:\n"
+        "      - from: \"guides/**\"\n"
+        "        into: \"kubernetes-resources\"\n"
+        "        under: \"API Reference\"\n"
+    )
+    rc = m.main(["--config", str(cfg), "--content-dir", str(content),
+                 "--mkdocs", str(mkdocs),
+                 "--set-repo", f"template-operator={repo}"])
+    assert rc == 0
+    assert (content / "kubernetes-resources/template-operator/create.md").is_file()

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -161,6 +161,50 @@ def test_read_nav_missing_raises():
         m.read_nav("site_name: x\n")
 
 
+# --- link rewriting (Path B) ---
+
+def test_rewrite_links_cross_folder():
+    # getting-started page links to a guides page; both moved under different roots
+    mapping = {
+        "getting-started/quick-start.md": "getting-started/hib/quick-start.md",
+        "guides/create-resource-supervisor.md": "guides/hib/create-resource-supervisor.md",
+    }
+    text = "See [guide](../guides/create-resource-supervisor.md)."
+    out = m.rewrite_links(text, "getting-started/quick-start.md",
+                          "getting-started/hib/quick-start.md", mapping)
+    assert out == "See [guide](../../guides/hib/create-resource-supervisor.md)."
+
+
+def test_rewrite_links_image_and_anchor():
+    mapping = {
+        "getting-started/installation/openshift.md": "getting-started/hib/installation/openshift.md",
+        "images/operatorHub.png": "images/hib/operatorHub.png",
+        "getting-started/installation/kubernetes.md": "getting-started/hib/installation/kubernetes.md",
+    }
+    src = "getting-started/installation/openshift.md"
+    dst = "getting-started/hib/installation/openshift.md"
+    img = m.rewrite_links("![oh](../../images/operatorHub.png)", src, dst, mapping)
+    assert img == "![oh](../../../images/hib/operatorHub.png)"
+    # anchor is preserved
+    link = m.rewrite_links("[k](kubernetes.md#argocd)", src, dst, mapping)
+    assert link == "[k](kubernetes.md#argocd)"  # same dir, resolves to itself? -> in map
+
+
+def test_rewrite_links_leaves_external_and_uncopied():
+    mapping = {"a/x.md": "a/slug/x.md"}
+    text = ("[ext](https://example.com) [anchor](#section) "
+            "[abs](/root.md) [missing](../other/y.md)")
+    out = m.rewrite_links(text, "a/x.md", "a/slug/x.md", mapping)
+    assert out == text  # nothing in map is referenced; all left as-is
+
+
+def test_rewrite_links_reference_style():
+    mapping = {"guides/b.md": "guides/slug/b.md", "images/x.png": "images/slug/x.png"}
+    text = "See ![img][ref].\n\n[ref]: ../images/x.png\n"
+    out = m.rewrite_links(text, "guides/b.md", "guides/slug/b.md", mapping)
+    assert "[ref]: ../../images/slug/x.png" in out
+
+
 # combine_mkdocs_config_yaml.py emits the merged config via PyYAML, which puts
 # sequence items under a mapping key at column 0 (indentless). read_nav/write_nav
 # must handle that, not just the hand-indented theme_override style above.

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -58,10 +58,11 @@ def test_compute_dest():
 
 
 def test_build_nav_tree_nests_folders():
+    # entries: (remainder, dest, src)
     entries = [
-        ("template.md", "kubernetes-resources/template-operator/template.md"),
-        ("how-to-guides/copy.md", "kubernetes-resources/template-operator/how-to-guides/copy.md"),
-        ("how-to-guides/deploy.md", "kubernetes-resources/template-operator/how-to-guides/deploy.md"),
+        ("template.md", "kubernetes-resources/template-operator/template.md", "reference/template.md"),
+        ("how-to-guides/copy.md", "kubernetes-resources/template-operator/how-to-guides/copy.md", "reference/how-to-guides/copy.md"),
+        ("how-to-guides/deploy.md", "kubernetes-resources/template-operator/how-to-guides/deploy.md", "reference/how-to-guides/deploy.md"),
     ]
     assert m.build_nav_tree(entries) == [
         {"How To Guides": [
@@ -72,10 +73,25 @@ def test_build_nav_tree_nests_folders():
     ]
 
 
+def test_build_nav_tree_uses_folder_titles_from_source_nav():
+    # folder "api" (source reference/api) is titled from the sub-op nav, not prettify
+    entries = [
+        ("api/rs.md", "kubernetes-resources/hib/api/rs.md", "reference/api/rs.md"),
+    ]
+    titles = {"reference/api": "API Reference"}
+    assert m.build_nav_tree(entries, titles) == [
+        {"API Reference": ["kubernetes-resources/hib/api/rs.md"]},
+    ]
+    # fallback to prettify when the source folder isn't in the map
+    assert m.build_nav_tree(entries) == [
+        {"Api": ["kubernetes-resources/hib/api/rs.md"]},
+    ]
+
+
 def test_build_nav_tree_duplicate_remainder_raises():
     entries = [
-        ("template.md", "kubernetes-resources/into-a/template.md"),
-        ("template.md", "kubernetes-resources/into-b/template.md"),
+        ("template.md", "kubernetes-resources/into-a/template.md", "a/template.md"),
+        ("template.md", "kubernetes-resources/into-b/template.md", "b/template.md"),
     ]
     with pytest.raises(ValueError):
         m.build_nav_tree(entries)
@@ -83,11 +99,29 @@ def test_build_nav_tree_duplicate_remainder_raises():
 
 def test_build_nav_tree_folder_file_conflict_raises():
     entries = [
-        ("a", "kubernetes-resources/a"),
-        ("a/b.md", "kubernetes-resources/a/b.md"),
+        ("a", "kubernetes-resources/a", "x/a"),
+        ("a/b.md", "kubernetes-resources/a/b.md", "x/a/b.md"),
     ]
     with pytest.raises(ValueError):
         m.build_nav_tree(entries)
+
+
+def test_nav_folder_titles_from_nav():
+    nav = [
+        {"Reference": [
+            {"API Reference": [
+                "reference/api/resource-supervisor.md",
+                "reference/api/cluster-resource-supervisor.md",
+            ]},
+            "reference/configuration.md",
+            "reference/rbac.md",
+        ]},
+        {"Guides": ["guides/create-resource-supervisor.md"]},
+    ]
+    titles = m.nav_folder_titles(nav)
+    assert titles["reference/api"] == "API Reference"
+    assert titles["reference"] == "Reference"
+    assert titles["guides"] == "Guides"
 
 
 def _sample_nav():
@@ -170,9 +204,10 @@ def test_rewrite_links_cross_folder():
         "guides/create-resource-supervisor.md": "guides/hib/create-resource-supervisor.md",
     }
     text = "See [guide](../guides/create-resource-supervisor.md)."
-    out = m.rewrite_links(text, "getting-started/quick-start.md",
-                          "getting-started/hib/quick-start.md", mapping)
+    out, ext = m.rewrite_links(text, "getting-started/quick-start.md",
+                               "getting-started/hib/quick-start.md", mapping)
     assert out == "See [guide](../../guides/hib/create-resource-supervisor.md)."
+    assert ext == []
 
 
 def test_rewrite_links_image_and_anchor():
@@ -183,26 +218,59 @@ def test_rewrite_links_image_and_anchor():
     }
     src = "getting-started/installation/openshift.md"
     dst = "getting-started/hib/installation/openshift.md"
-    img = m.rewrite_links("![oh](../../images/operatorHub.png)", src, dst, mapping)
+    img, _ = m.rewrite_links("![oh](../../images/operatorHub.png)", src, dst, mapping)
     assert img == "![oh](../../../images/hib/operatorHub.png)"
     # anchor is preserved
-    link = m.rewrite_links("[k](kubernetes.md#argocd)", src, dst, mapping)
-    assert link == "[k](kubernetes.md#argocd)"  # same dir, resolves to itself? -> in map
+    link, _ = m.rewrite_links("[k](kubernetes.md#argocd)", src, dst, mapping)
+    assert link == "[k](kubernetes.md#argocd)"  # same dir, resolves to itself -> in map
 
 
 def test_rewrite_links_leaves_external_and_uncopied():
     mapping = {"a/x.md": "a/slug/x.md"}
     text = ("[ext](https://example.com) [anchor](#section) "
             "[abs](/root.md) [missing](../other/y.md)")
-    out = m.rewrite_links(text, "a/x.md", "a/slug/x.md", mapping)
-    assert out == text  # nothing in map is referenced; all left as-is
+    # no live_url -> unmatched links left as-is
+    out, ext = m.rewrite_links(text, "a/x.md", "a/slug/x.md", mapping)
+    assert out == text
+    assert ext == []
 
 
 def test_rewrite_links_reference_style():
     mapping = {"guides/b.md": "guides/slug/b.md", "images/x.png": "images/slug/x.png"}
     text = "See ![img][ref].\n\n[ref]: ../images/x.png\n"
-    out = m.rewrite_links(text, "guides/b.md", "guides/slug/b.md", mapping)
+    out, _ = m.rewrite_links(text, "guides/b.md", "guides/slug/b.md", mapping)
     assert "[ref]: ../../images/slug/x.png" in out
+
+
+# --- external (live_url) fallback for non-whitelisted targets ---
+
+def test_rewrite_links_external_directory_style():
+    mapping = {"guides/b.md": "guides/slug/b.md"}   # only b is whitelisted
+    text = "See [arch](../concepts/architecture.md#intro)."
+    out, ext = m.rewrite_links(text, "guides/b.md", "guides/slug/b.md", mapping,
+                               live_url="https://docs.example.com/op/",
+                               live_url_style="directory")
+    assert out == "See [arch](https://docs.example.com/op/concepts/architecture/#intro)."
+    assert ext == ["concepts/architecture.md"]
+
+
+def test_rewrite_links_external_html_style():
+    mapping = {"guides/b.md": "guides/slug/b.md"}
+    text = "[cfg](../reference/configuration.md)"
+    out, _ = m.rewrite_links(text, "guides/b.md", "guides/slug/b.md", mapping,
+                             live_url="https://docs.example.com/op", live_url_style="html")
+    assert out == "[cfg](https://docs.example.com/op/reference/configuration.html)"
+
+
+def test_rewrite_links_external_index_and_asset():
+    mapping = {"guides/b.md": "guides/slug/b.md"}
+    src, dst = "guides/b.md", "guides/slug/b.md"
+    home, _ = m.rewrite_links("[home](../index.md)", src, dst, mapping,
+                              live_url="https://docs.example.com/op/")
+    assert home == "[home](https://docs.example.com/op/)"
+    img, _ = m.rewrite_links("![d](../images/diagram.png)", src, dst, mapping,
+                             live_url="https://docs.example.com/op/")
+    assert img == "![d](https://docs.example.com/op/images/diagram.png)"
 
 
 # combine_mkdocs_config_yaml.py emits the merged config via PyYAML, which puts

--- a/tests/test_merge_docs.py
+++ b/tests/test_merge_docs.py
@@ -331,6 +331,7 @@ operators:
     repo: ../hibernation-operator-docs
     slug: hib
     docs_dir: site
+    branch: develop
     exclude: ["**/.gitkeep"]
     mappings:
       - from: "guides/**"
@@ -346,9 +347,11 @@ def test_load_config_defaults(tmp_path):
     assert ops[0]["slug"] == "template-operator"
     assert ops[0]["docs_dir"] == "content"
     assert ops[0]["exclude"] == []
+    assert ops[0]["branch"] == ""          # default -> repo default branch
     assert ops[1]["slug"] == "hib"
     assert ops[1]["docs_dir"] == "site"
     assert ops[1]["exclude"] == ["**/.gitkeep"]
+    assert ops[1]["branch"] == "develop"
 
 
 def test_run_copies_files_and_injects_nav(tmp_path):


### PR DESCRIPTION
# Merge sub-operator docs at build time

Adds a build-time tool that merges the docs of sub-operators (Template, Hibernation) into the MTO docs site, driven by a single `merge.yaml`. Sub-operator content is fetched in CI and never committed here.

## How it works

`scripts/merge_docs.py` reads `merge.yaml` and, per operator:

- **Copies** whitelisted files (glob `from` + `exclude`) into `content/<into>/<slug>/…`.
- **Builds nav** for the copied `.md` pages and nests it under an existing menu section (`under`), with folder titles taken from the sub-operator's own nav (falling back to title-case). Splices only the `nav:` block of the combined `mkdocs.yml`, leaving the rest byte-for-byte.
- **Rewrites links**: whitelisted targets → local relative links; anything else → the operator's published site (`live_url`, `directory`/`html` style), anchors preserved. Externalized links are logged.

`merge.yaml` is the whitelist; the tool fails fast on empty globs, collisions, missing repos, or unknown menu sections.

## Integration

- **CI**: `pull_request.yaml` and `push.yaml` run `PRE_BUILD_HOOK: make merge` after theme-combine, before `mike deploy` (shared workflows at `v0.0.189`). `scripts/pre_build_merge.sh` clones each repo (token-aware) and runs the merge. `release.yaml` only containerizes the already-built `gh-pages`, so it needs no hook.
- **Local**: `make serve` (combine + merge + `mkdocs serve`), `make merge`, `make clean`.
- `DockerfileLocal` gains an optional, arg-gated merge step (skipped when unset).

## Verified

- `mkdocs build --strict` passes (0 warnings) against the live `main` branches of both sub-operators.
- 34 unit tests (path/glob/nav/link-rewriting/title-derivation).

## Notes

- `merge.yaml` `into`/`under` target the current MTO nav; they collapse to ~1:1 pairs once MTO migrates to new structure.
