### PR TITLE
Update branch field for operators in merge.yaml

### DIFF
--- a/merge.yaml
+++ b/merge.yaml
@@ -14,7 +14,7 @@ site_title: "Tenant Operator"
 operators:
   - title: Template Operator
     repo: https://github.com/stakater/template-operator-docs.git
-    branch: added-concepts            # optional; empty -> the repo's default branch
+    # branch: main             # optional; empty -> the repo's default branch
     # links to pages NOT whitelisted below fall back to this published site
     live_url: https://docs.stakater.com/template-operator-docs/
     live_url_style: directory
@@ -41,7 +41,7 @@ operators:
 
   - title: Hibernation Operator
     repo: https://github.com/stakater/hibernation-operator-docs.git
-    branch: added-concepts            # optional; empty -> the repo's default branch
+    # branch: main            # optional; empty -> the repo's default branch
     live_url: https://docs.stakater.com/hibernation-operator-docs/
     live_url_style: html          # sub-op uses use_directory_urls: false
     mappings:


### PR DESCRIPTION
Commented out the 'branch' field for two operators to default to the main branch.